### PR TITLE
Fixing a macro definition, unifying the behavior of clang and gcc

### DIFF
--- a/x11-drivers/xf86-video-intel/files/patch-src_intel__list.h
+++ b/x11-drivers/xf86-video-intel/files/patch-src_intel__list.h
@@ -1,9 +1,15 @@
-These functions are copied from the xorg-server.
-http://lists.x.org/archives/xorg-devel/2016-January/048421.html
-
---- src/intel_list.h.orig	2014-08-29 11:33:11.000000000 +0200
-+++ src/intel_list.h	2016-01-06 14:03:26.792064000 +0100
-@@ -326,12 +326,14 @@
+--- src/intel_list.h.orig	2015-12-10 23:29:35.000000000 +0100
++++ src/intel_list.h	2016-10-24 10:22:57.280379000 +0200
+@@ -306,7 +306,7 @@
+     list_entry((ptr)->prev, type, member)
+ 
+ #define __container_of(ptr, sample, member)				\
+-    (void *)((char *)(ptr) - ((char *)&(sample)->member - (char *)(sample)))
++    (typeof(sample))((char *)(ptr) - (offsetof(typeof(*sample),member)))
+ /**
+  * Loop through the list given by head and set pos to struct in the list.
+  *
+@@ -325,12 +325,14 @@
   *
   */
  #define list_for_each_entry(pos, head, member)				\
@@ -21,7 +27,7 @@ http://lists.x.org/archives/xorg-devel/2016-January/048421.html
  	 &pos->member != (head);					\
  	 pos = __container_of(pos->member.prev, pos, member))
  
-@@ -343,7 +345,8 @@
+@@ -342,7 +344,8 @@
   * See list_for_each_entry for more details.
   */
  #define list_for_each_entry_safe(pos, tmp, head, member)		\


### PR DESCRIPTION
This patch is a way to fix the build of xf86-video-intel using clang.
Intel DDX redefines the macro __container_of() already present in xorg/list.h
It seems that using pointer arithmetic to compute the field displacement can potentially cause a segmentation fault (maybe disable optimizations plays a role).
The suggested solution, based of builtins like typeof() and offsetof() provides a modern and clean solution.
This solution is based on what in xorg/list.h is already implemented if typeof() builtin is recognized (via the CPP symbol HAVE_TYPEOF)